### PR TITLE
feature/SPL12-implement-state-machine-framework

### DIFF
--- a/workspace/nucleo144/Sources.cmake
+++ b/workspace/nucleo144/Sources.cmake
@@ -4,8 +4,11 @@ set( PROJECT_SOURCES
         src/bluetooth.c
         src/button.c
         src/error.c
+        src/ErrorState.c
         src/ESP8266.c
         src/events.c
+        src/fsm_evt_queue.c
+        src/InitState.c
         src/main.c
         src/microphone.c
         src/server.c
@@ -15,6 +18,7 @@ set( PROJECT_SOURCES
         src/stm32l4xx_it.c
         #src/syscalls.c
         src/system_stm32l4xx.c
+        src/TestState.c
 
 
         HAL_Driver/src/stm32l4xx_hal_rcc.c
@@ -123,8 +127,11 @@ set( PROJECT_SOURCES
         inc/button.h
         inc/common.h
         inc/error.h
+        inc/ErrorState.h
         inc/ESP8266.h
         inc/events.h
+        inc/fsm_evt_queue.h
+        inc/InitState.h
         inc/main.h
         inc/microphone.h
         inc/server.h
@@ -133,6 +140,7 @@ set( PROJECT_SOURCES
         inc/stm32l4xx_hal_conf.h
         inc/stm32l4xx_it.h
         inc/stm32_assert.h
+        inc/TestState.h
 
         HAL_Driver/inc/stm32l4xx_ll_pwr.h
         HAL_Driver/inc/stm32l4xx_hal_opamp.h

--- a/workspace/nucleo144/inc/ErrorState.h
+++ b/workspace/nucleo144/inc/ErrorState.h
@@ -1,0 +1,9 @@
+#ifndef __ERROR_STATE_H
+#define __ERROR_STATE_H
+
+#include "common.h"
+#include "state_machine.h"
+
+bool ErrorState(Fsm* me, FSM_EVT_T const *event);
+
+#endif /* __ERROR_STATE_H */

--- a/workspace/nucleo144/inc/InitState.h
+++ b/workspace/nucleo144/inc/InitState.h
@@ -1,0 +1,9 @@
+#ifndef __INIT_STATE_H
+#define __INIT_STATE_H
+
+#include "common.h"
+#include "state_machine.h"
+
+bool InitState(Fsm* me, FSM_EVT_T const *event);
+
+#endif /* __INIT_STATE_H */

--- a/workspace/nucleo144/inc/SPH0645.h
+++ b/workspace/nucleo144/inc/SPH0645.h
@@ -5,8 +5,9 @@
 #include "stm32l4xx.h"
 
 bool SPH0645_Init(void);
-HAL_StatusTypeDef SPH0645_StartRecord(uint8_t *buff, uint16_t size);
+HAL_StatusTypeDef SPH0645_StartRecord(uint8_t *buff, uint16_t length);
 HAL_StatusTypeDef SPH0645_StopRecord(void);
+uint16_t SPH0645_GetNumUnitsLeft(void);
 
 void SPH0645_SAIRxCpltCallback(SAI_HandleTypeDef *hsai);
 DMA_HandleTypeDef* SPH0645_GetDMAHandle(void);

--- a/workspace/nucleo144/inc/TestState.h
+++ b/workspace/nucleo144/inc/TestState.h
@@ -1,0 +1,9 @@
+#ifndef __TEST_STATE_H
+#define __TEST_STATE_H
+
+#include "common.h"
+#include "state_machine.h"
+
+bool TestState_Standby(Fsm* me, FSM_EVT_T const *event);
+
+#endif /* __TEST_STATE_H */

--- a/workspace/nucleo144/inc/fsm_evt_queue.h
+++ b/workspace/nucleo144/inc/fsm_evt_queue.h
@@ -1,0 +1,51 @@
+#ifndef __FSM_EVT_QUEUE_H
+#define __FSM_EVT_QUEUE_H
+
+#include "common.h"
+
+typedef enum
+{
+    FSM_EVT_MIN = 0,
+    FSM_EVT_USER_BUTTON_PRESS = FSM_EVT_MIN,
+    FSM_EVT_AUDIO_TRANSFER_DONE,
+    FSM_EVT_AUDIO_RECORD_DONE,
+    FSM_EVT_ERROR,
+    FSM_EVT_MAX
+} FSM_EVT_ID_T;
+
+typedef struct FSM_EVT_T {
+    FSM_EVT_ID_T id;
+    uint32_t size; // Size of data stored in data buffer, if any
+    uint8_t* data;
+} FSM_EVT_T;
+
+typedef struct FSM_EVT_QUEUE_T {
+    FSM_EVT_T* buffer;
+    uint32_t capacity;
+    uint32_t mask;
+    uint32_t count;
+    uint32_t head;
+    uint32_t watermark;
+} FSM_EVT_QUEUE_T;
+
+#define IS_POWER_OF_TWO(x) (((x) != 0) && (((x) & ((x) - 1)) == 0))
+
+#define FSM_EVT_QUEUE_INIT(_name_, _capacity_)                               \
+    _Static_assert(IS_POWER_OF_TWO(_capacity_), "Capacity not power of 2");  \
+    static FSM_EVT_T _name_##_buf[_capacity_];                               \
+    static FSM_EVT_QUEUE_T _name_ = {                                        \
+        .buffer = _name_##_buf,                                              \
+        .capacity = _capacity_,                                              \
+        .mask = _capacity_ - 1,                                              \
+        .head = 0,                                                           \
+        .count = 0,                                                          \
+        .watermark = 0,                                                      \
+    }
+
+bool FSM_EVT_QUEUE_Push(FSM_EVT_T data);
+bool FSM_EVT_QUEUE_Pop(FSM_EVT_T* data);
+void FSM_EVT_QUEUE_Clear(void);
+bool FSM_EVT_QUEUE_IsFull(void);
+bool FSM_EVT_QUEUE_IsEmpty(void);
+
+#endif /* __FSM_EVT_QUEUE_H */

--- a/workspace/nucleo144/inc/server.h
+++ b/workspace/nucleo144/inc/server.h
@@ -35,6 +35,8 @@ typedef enum SERVER_CMD_T
 {
     SERVER_MIN_CMD = 0,
     SERVER_HEADER_CMD = SERVER_MIN_CMD,
+    SERVER_START_TRAIN_CMD,
+    SERVER_TRAIN_CMD,
     SERVER_PAYLOAD_CMD,
     SERVER_TEST_CMD,
     SERVER_MAX_CMD
@@ -43,8 +45,8 @@ typedef enum SERVER_CMD_T
 bool Server_Init(void);
 void Server_Update(void);
 
-bool Server_StartAudioTx(uint32_t transferSize, uint8_t* txData);
-bool Server_TransmitPacket(uint16_t cmd, uint32_t payloadSize, uint16_t packetNum, uint8_t* txData);
+bool Server_StartAudioTx(SERVER_CMD_T cmd, uint32_t transferSize, uint8_t* txData);
+bool Server_TransmitPacket(SERVER_CMD_T cmd, uint32_t payloadSize, uint16_t packetNum, uint8_t* txData);
 bool Server_TransmitTest(void);
 
 #endif /* __SERVER_H */

--- a/workspace/nucleo144/inc/state_machine.h
+++ b/workspace/nucleo144/inc/state_machine.h
@@ -1,20 +1,23 @@
 #ifndef __STATE_MACHINE_H
 #define __STATE_MACHINE_H
 
-
+#include "fsm_evt_queue.h"
 #include "stm32l4xx.h"
 
-typedef enum
-{
-    stateReset = 0,
-    stateStandby,
-    stateRec,
-    stateProc,
-    stateCal,
-    stateErr
-} sm_state_t;
+typedef struct Fsm Fsm;
+typedef bool (*State)(Fsm *, FSM_EVT_T const *);
 
-HAL_StatusTypeDef smInit(sm_state_t* state);
-void smRun(sm_state_t* state);
+struct Fsm
+{
+    State state__;
+};
+
+#define FsmCtor_(me_, init_) ((me_)->state__ = (State)(init_))
+#define FsmInit(me_, e_)     (*(me_)->state__)((me_), (e_))
+#define FsmDispatch(me_, e_) (*(me_)->state__)((me_), (e_))
+#define FsmTran_(me_, targ_) ((me_)->state__ = (State)(targ_))
+
+HAL_StatusTypeDef StateMachine_Init(void);
+void StateMachine_Run(void);
 
 #endif /* __STATE_MACHINE_H */

--- a/workspace/nucleo144/src/ErrorState.c
+++ b/workspace/nucleo144/src/ErrorState.c
@@ -1,0 +1,20 @@
+/*
+ * ErrorState.c
+ *
+ *      Author: jessechen
+ *      Brief:
+ *          - This file provides set of firmware functions to manage:
+ *          - Error state handling
+ */
+//
+
+#include "fsm_evt_queue.h"
+#include "InitState.h"
+#include "stm32l4xx_nucleo_144.h"
+
+/* Private functions ---------------------------------------------------------*/
+
+bool ErrorState(Fsm* me, FSM_EVT_T const *event) {
+    BSP_LED_On(LED3);
+    return true;
+}

--- a/workspace/nucleo144/src/InitState.c
+++ b/workspace/nucleo144/src/InitState.c
@@ -1,0 +1,20 @@
+/*
+ * InitState.c
+ *
+ *      Author: jessechen
+ *      Brief:
+ *          - This file provides set of firmware functions to manage:
+ *          - State initialization
+ */
+//
+
+#include "fsm_evt_queue.h"
+#include "InitState.h"
+#include "TestState.h"
+
+/* Private functions ---------------------------------------------------------*/
+
+bool InitState(Fsm* me, FSM_EVT_T const *event) {
+    FsmTran_(me, &TestState_Standby);
+    return true;
+}

--- a/workspace/nucleo144/src/SPH0645.c
+++ b/workspace/nucleo144/src/SPH0645.c
@@ -98,9 +98,12 @@ bool SPH0645_Init(void){
     return success;
 }
 
+uint16_t SPH0645_GetNumUnitsLeft(void) {
+    return m_MemsDmaHandler.Instance->CNDTR;
+}
 
-HAL_StatusTypeDef SPH0645_StartRecord(uint8_t *buff, uint16_t size) {
-    return HAL_SAI_Receive_DMA(&m_MemsSaiHandler, buff, size);
+HAL_StatusTypeDef SPH0645_StartRecord(uint8_t *buff, uint16_t length) {
+    return HAL_SAI_Receive_DMA(&m_MemsSaiHandler, buff, length);
 }
 
 HAL_StatusTypeDef SPH0645_StopRecord(void) {
@@ -123,7 +126,7 @@ static bool SAI1ClockInit(void) {
     // Set clock config
     // Since we want 16 kHz sampling with 64 bit word select period (even though
     // active frame is only 32 bits), need clock of least 16kHz * 64 bits * 2 = 2.048 MHz
-    
+
     // Due to internal resynchronization stages, PCLK APB frequency must be higher than twice
     // the bit rate clock frequency.
 

--- a/workspace/nucleo144/src/TestState.c
+++ b/workspace/nucleo144/src/TestState.c
@@ -1,0 +1,100 @@
+/*
+ * TestState.c
+ *
+ *      Author: jessechen
+ *      Brief:
+ *          - This file provides set of firmware functions to manage:
+ *          - The testing state (allows free form sending of audio data)
+ */
+//
+
+#include "ErrorState.h"
+#include "ESP8266.h"
+#include "events.h"
+#include "fsm_evt_queue.h"
+#include "microphone.h"
+#include "server.h"
+#include "state_machine.h"
+#include "stm32l4xx_nucleo_144.h"
+#include "TestState.h"
+
+/* Private functions ---------------------------------------------------------*/
+static bool RecordState(Fsm* me, FSM_EVT_T const *event);
+static bool ProcessingState(Fsm* me, FSM_EVT_T const *event);
+
+bool TestState_Standby(Fsm* me, FSM_EVT_T const *event) {
+    State newState = &TestState_Standby;
+    bool eventHandled = true;
+
+    switch(event->id)
+    {
+        case FSM_EVT_USER_BUTTON_PRESS:
+            if (Mic_StartRecord() == HAL_OK) {
+                newState = &RecordState;
+            }
+            else {
+                newState = &ErrorState;
+            }
+            break;
+
+        default:
+            eventHandled = false;
+            break;
+    }
+
+    FsmTran_(me, newState);
+    return eventHandled;
+}
+
+static bool RecordState(Fsm* me, FSM_EVT_T const *event) {
+    State newState = &RecordState;
+    bool eventHandled = true;
+
+    uint32_t size = 0;
+    AUDIO_SIZE_T* audioData;
+
+    switch(event->id)
+    {
+        // Intentional fall through
+        case FSM_EVT_AUDIO_RECORD_DONE:
+        case FSM_EVT_USER_BUTTON_PRESS:
+            if (Mic_StopRecord() == HAL_OK) {
+                audioData = Mic_GetAudioData(&size);
+                if(Server_StartAudioTx(SERVER_TEST_CMD, size, (uint8_t*)audioData) == true) {
+                    newState = &ProcessingState;
+                }
+                else {
+                    newState = &ErrorState;
+                }
+            }
+            else {
+                newState = &ErrorState;
+            }
+            break;
+
+        default:
+            eventHandled = false;
+            break;
+    }
+
+    FsmTran_(me, newState);
+    return eventHandled;
+}
+
+static bool ProcessingState(Fsm* me, FSM_EVT_T const *event) {
+    State newState = &ProcessingState;
+    bool eventHandled = true;
+
+    switch(event->id)
+    {
+        case FSM_EVT_AUDIO_TRANSFER_DONE:
+            newState = &TestState_Standby;
+
+        default:
+            eventHandled = false;
+            break;
+    }
+
+    FsmTran_(me, newState);
+    return eventHandled;
+}

--- a/workspace/nucleo144/src/button.c
+++ b/workspace/nucleo144/src/button.c
@@ -11,6 +11,7 @@
 /* Includes ------------------------------------------------------------------*/
 #include "button.h"
 #include "events.h"
+#include "fsm_evt_queue.h"
 #include "stm32l4xx.h"
 #include "stm32l4xx_hal_gpio.h"
 #include "stm32l4xx_hal_tim.h"
@@ -117,9 +118,16 @@ static void HandleDebounce(void){
     if(m_consecutiveCounts > REQUIRED_CONSECUTIVE_COUNTS){
         m_consecutiveCounts = 0;
         m_debounceFlag = false;
-        // If button was pressed, set event
+        // If button was pressed, set fsm event
         if (pressed == true){
-            Event_Set(EVENT_USER_BUTTON_PRESS);
+
+            FSM_EVT_T event = {
+                .id = FSM_EVT_USER_BUTTON_PRESS,
+                .size = 0,
+                .data = NULL
+            };
+
+            FSM_EVT_QUEUE_Push(event);
         }
         HAL_TIM_Base_Stop_IT(&m_buttonTmr);
     }

--- a/workspace/nucleo144/src/fsm_evt_queue.c
+++ b/workspace/nucleo144/src/fsm_evt_queue.c
@@ -1,0 +1,91 @@
+/*
+ * fsm_evt_queue.c
+ *
+ *      Author: jessechen
+ *      Brief:
+ *          - This file provides set of firmware functions to manage:
+ *          - State machine event queue functionality
+ */
+//
+
+/* Includes ------------------------------------------------------------------*/
+#include "error.h"
+#include "fsm_evt_queue.h"
+#include "stm32l4xx_nucleo_144.h"
+
+
+/** @addtogroup Templates
+  * @{
+  */
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+#define EVT_QUEUE_CAPACITY 64
+/* Private variables ---------------------------------------------------------*/
+FSM_EVT_QUEUE_INIT(m_EvtQueue, EVT_QUEUE_CAPACITY);
+
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+
+bool FSM_EVT_QUEUE_Push(FSM_EVT_T data) {
+    bool success = true;
+
+    __disable_irq();
+    if(FSM_EVT_QUEUE_IsFull() == true) {
+        // For now just go into forever loop if this happens
+        Error_Handler();
+        success = false;
+    }
+
+    if(success == true) {
+        uint32_t tail = (m_EvtQueue.count + m_EvtQueue.head) & m_EvtQueue.mask;
+        m_EvtQueue.count++;
+        m_EvtQueue.buffer[tail] = data;
+
+        if(m_EvtQueue.count > m_EvtQueue.watermark) {
+            m_EvtQueue.watermark = m_EvtQueue.count;
+        }
+    }
+    __enable_irq();
+
+    return success;
+}
+
+bool FSM_EVT_QUEUE_Pop(FSM_EVT_T* data) {
+    bool success = true;
+
+    __disable_irq();
+
+    if(FSM_EVT_QUEUE_IsEmpty() == true) {
+        success = false;
+    }
+
+    if(success == true) {
+        m_EvtQueue.count--;
+        *data = m_EvtQueue.buffer[m_EvtQueue.head];
+        m_EvtQueue.head = (m_EvtQueue.head + 1) & m_EvtQueue.mask;
+    }
+
+    __enable_irq();
+
+    return success;
+}
+
+void FSM_EVT_QUEUE_Clear(void) {
+    __disable_irq();
+    m_EvtQueue.count = 0;
+    m_EvtQueue.head = 0;
+    __enable_irq();
+}
+
+// TODO: Add critical sections to below functions when nested critical sections
+// are implemented
+bool FSM_EVT_QUEUE_IsFull(void) {
+    return (m_EvtQueue.capacity <= m_EvtQueue.count);
+}
+
+bool FSM_EVT_QUEUE_IsEmpty(void) {
+    return (m_EvtQueue.count == 0);
+}

--- a/workspace/nucleo144/src/main.c
+++ b/workspace/nucleo144/src/main.c
@@ -37,7 +37,6 @@
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 static SPI_HandleTypeDef spi_h;
-static char test_string[] = "Test string\r\n";
 
 GPIO_InitTypeDef test_pin;
 extern ADC_HandleTypeDef adc_h;
@@ -59,8 +58,6 @@ static void SystemClock_Config(void);
   */
 int main(void)
 {
-  static sm_state_t state;
-
   /* STM32L4xx HAL library initialization:
        - Configure the Flash prefetch, Flash preread and Buffer caches
        - Systick timer is configured by default as source of time base, but user
@@ -148,49 +145,17 @@ int main(void)
   HAL_GPIO_Init(NUCLEO_ADCx_GPIO_PORT, &test_pin);
 
 
-/* Start ADC reads */
-  // if (HAL_ADC_Start_DMA(&adc_h, (uint32_t*)audio_data, AUDIO_DATA_BUFFER_SIZE) != HAL_OK){
-  //     Error_Handler();
-  // }
-  //
-  // HAL_Delay(500);
-  //
-  // // Stop DMA reads
-  // if (HAL_ADC_Stop_DMA(&adc_h) != HAL_OK){
-  //   Error_Handler();
-  // }
-  //
-  // // Switch channel rankings
-  // ADC_CalibrateVRefInt();
-  //
-  // /* Start ADC reads */
-  // if (HAL_ADC_Start_DMA(&adc_h, (uint32_t*)audio_data, AUDIO_DATA_BUFFER_SIZE) != HAL_OK){
-  //     Error_Handler();
-  // }
-  //
-  // HAL_Delay(500);
-
   /* Infinite loop */
 
-  state = stateStandby;
+  StateMachine_Init();
   while (1)
   {
     if(Event_GetAndClear(EVENT_AUDIO_TRANSFER_ERROR)){
         Error_Handler();
     }
-    smRun(&state);
+    StateMachine_Run();
     Server_Update();
-	// Blink LED1
-// 	BSP_LED_On(LED1);
-// 	BLE_WriteUART(test_string, sizeof(test_string));
-// 	HAL_Delay(500);
-//
-// //	if (HAL_ADC_Stop_DMA(&adc_h) != HAL_OK){
-// //	  Error_Handler();
-// //	}
-//
-// 	BSP_LED_Off(LED1);
-// 	HAL_Delay(500);
+
   }
 }
 /* End of main function */

--- a/workspace/nucleo144/src/stm32l4xx_it.c
+++ b/workspace/nucleo144/src/stm32l4xx_it.c
@@ -162,3 +162,21 @@ void HAL_SPI_AbortCpltCallback(SPI_HandleTypeDef *hspi){
         m_ErrorCount++;
     }
 }
+
+void HardFault_Handler(void) {
+    BSP_LED_On(LED3);
+    while(1) {
+    }
+}
+
+void UsageFault_Handler(void) {
+    BSP_LED_On(LED3);
+    while(1) {
+    }
+}
+
+void BusFault_Handler(void) {
+    BSP_LED_On(LED3);
+    while(1) {
+    }
+}


### PR DESCRIPTION
SPL12 Implement event queue based state machine framework
* States represented as function pointers which take events as input.
  Events enumerated with IDs and optional associated data. State machine
  runs until event queue is empty. Programming by difference implemented by
  checking if a particular state has handled an event or not.
* Modify server.c and microphone.c to only send over data which is recorded
  instead of entire buffer by default.

Resolves #12 